### PR TITLE
fix ruamel.yaml on 0.14.x for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
 
     packages=find_packages(),
 
-    install_requires=['ruamel.yaml', 'argparse', 'tabulate', 'termcolor', 'jinja2', 'pygraphviz'],
+    install_requires=['ruamel.yaml<0.15', 'argparse', 'tabulate', 'termcolor', 'jinja2', 'pygraphviz'],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that your user could see. 
Therefore please release a version of ansiqa with this change, so that it will not automatically take the latest ruamel.yaml release without your endorsement